### PR TITLE
fix: map pb lamps from str instead of indexes

### DIFF
--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -41,7 +41,7 @@ pub fn process_pbs(user: &str, music: &Node) -> Result<Node> {
             let song_id = chart["data"]["inGameID"].as_u64().ok_or(anyhow::anyhow!(
                 "Could not parse ingame ID from Tachi PBs API"
             ))? as u32;
-            let difficulty = match chart["difficulty"].as_str().ok_or(anyhow::anyhow!(
+            let difficulty: u8 = match chart["difficulty"].as_str().ok_or(anyhow::anyhow!(
                 "Could not parse difficulty from Tachi PBs API"
             ))? {
                 "NOV" => 0,
@@ -91,12 +91,17 @@ pub fn process_pbs(user: &str, music: &Node) -> Result<Node> {
         let score = pb["scoreData"]["score"].as_u64().ok_or(anyhow::anyhow!(
             "Could not parse PB score from Tachi PBs API"
         ))?;
-        let lamp = pb["scoreData"]["enumIndexes"]["lamp"]
-            .as_u64()
-            .ok_or(anyhow::anyhow!(
-                "Could not parse PB lamp from Tachi PBs API"
-            ))?
-            + 1;
+        let lamp: u64 = match pb["scoreData"]["lamp"].as_str().ok_or(anyhow::anyhow!(
+            "Could not parse lamp from Tachi PBs API"
+        ))? {
+            "FAILED" => 1,
+            "CLEAR" => 2,
+            "EXCESSIVE CLEAR" => 3,
+            "ULTIMATE CHAIN" => 4,
+            "PERFECT ULTIMATE CHAIN" => 5,
+            "MAXXIVE CLEAR" => 6,
+            _ => 0,
+        };
         let grade = pb["scoreData"]["enumIndexes"]["grade"]
             .as_u64()
             .ok_or(anyhow::anyhow!(

--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -41,7 +41,7 @@ pub fn process_pbs(user: &str, music: &Node) -> Result<Node> {
             let song_id = chart["data"]["inGameID"].as_u64().ok_or(anyhow::anyhow!(
                 "Could not parse ingame ID from Tachi PBs API"
             ))? as u32;
-            let difficulty: u8 = match chart["difficulty"].as_str().ok_or(anyhow::anyhow!(
+            let difficulty = match chart["difficulty"].as_str().ok_or(anyhow::anyhow!(
                 "Could not parse difficulty from Tachi PBs API"
             ))? {
                 "NOV" => 0,


### PR DESCRIPTION
Required due to Tachi not using indexes that match with ingame indexes anymore. Current build injects broken PBs, on pre maxxive and maxxive data.

UNTESTED ON PRE MAXXIVE, need to check the side effects of injecting maxxive scores on older game version. It might be needed to transform injected maxxive PBs to HCs based on detected datecode. Will update this PR once tested.