### PR TITLE
feat: Add multi-user support

### DIFF
--- a/mikado.toml
+++ b/mikado.toml
@@ -8,13 +8,6 @@ inject_cloud_pbs = true
 # Timeout for web requests, in milliseconds
 timeout = 3000
 
-[cards]
-# Card numbers that should be whitelisted
-# If this is empty, all cards will be whitelisted
-# E000 format, should be in single quotes and separated by commas
-# Example: whitelist = ['E000000000', 'E000000001']
-whitelist = []
-
 [tachi]
 # Tachi instance base URL
 base_url = 'https://kamaitachi.xyz/'
@@ -24,5 +17,12 @@ status = '/api/v1/status'
 import = '/ir/direct-manual/import'
 # Tachi pbs endpoint
 pbs = '/api/v1/users/{}/games/sdvx/Single/pbs/all'
-# Your Tachi API key
+
+# The Tachi API key to use for any card
+# If you only want specific cards to be recognized, omit this default entry
+[cards.default]
 api_key = 'your-key-here'
+
+# Example of a specific card entry
+# [cards.'E000000001']
+# api_key = 'another-key-here'

--- a/mikado.toml
+++ b/mikado.toml
@@ -8,6 +8,13 @@ inject_cloud_pbs = true
 # Timeout for web requests, in milliseconds
 timeout = 3000
 
+[cards]
+# Card numbers that should be whitelisted
+# If this is empty, all cards will be whitelisted
+# E000 format, should be in single quotes and separated by commas
+# Example: whitelist = ['E000000000', 'E000000001']
+whitelist = []
+
 [tachi]
 # Tachi instance base URL
 base_url = 'https://kamaitachi.xyz/'
@@ -17,12 +24,10 @@ status = '/api/v1/status'
 import = '/ir/direct-manual/import'
 # Tachi pbs endpoint
 pbs = '/api/v1/users/{}/games/sdvx/Single/pbs/all'
-
-# The Tachi API key to use for any card
-# If you only want specific cards to be recognized, omit this default entry
-[cards.default]
+# Your Tachi API key
 api_key = 'your-key-here'
 
-# Example of a specific card entry
-# [cards.'E000000001']
+# Example of a profile, used to associate specific cards with another API key.
+# [profiles.'profile-name']
+# cards = ['E000000002', 'E000000003']
 # api_key = 'another-key-here'

--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -24,7 +24,10 @@ fn build_response_base(scores: Vec<Node>) -> Node {
 // TODO: Refactor this whole mess
 pub fn process_pbs(user: &str, music: &Node) -> Result<Node> {
     let url = dynfmt::SimpleCurlyFormat.format(TACHI_PBS_URL.as_str(), [user])?;
-    let response: serde_json::Value = helpers::request_tachi("GET", url, None::<()>)?;
+
+    let user = helpers::get_current_user().ok_or(anyhow::anyhow!("No user during PB processing"))?;
+
+    let response: serde_json::Value = helpers::request_tachi("GET", url, user.card_config.api_key, None::<()>)?;
     let body = response["body"].as_object().ok_or(anyhow::anyhow!(
         "Could not parse response body from Tachi PBs API"
     ))?;

--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -27,7 +27,7 @@ pub fn process_pbs(user: &str, music: &Node) -> Result<Node> {
 
     let user = helpers::get_current_user().ok_or(anyhow::anyhow!("No user during PB processing"))?;
 
-    let response: serde_json::Value = helpers::request_tachi("GET", url, user.card_config.api_key, None::<()>)?;
+    let response: serde_json::Value = helpers::request_tachi("GET", url, user.profile.config.api_key, None::<()>)?;
     let body = response["body"].as_object().ok_or(anyhow::anyhow!(
         "Could not parse response body from Tachi PBs API"
     ))?;

--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -2,6 +2,7 @@ mod ext;
 
 use crate::types::cloudlink::{Chart, Score};
 use crate::types::tachi::{TachiDifficulty, TachiLamp};
+use crate::types::user::User;
 use crate::{helpers, mikado, TACHI_PBS_URL};
 use anyhow::Result;
 use dynfmt::Format;
@@ -22,10 +23,8 @@ fn build_response_base(scores: Vec<Node>) -> Node {
 }
 
 // TODO: Refactor this whole mess
-pub fn process_pbs(user: &str, music: &Node) -> Result<Node> {
-    let url = dynfmt::SimpleCurlyFormat.format(TACHI_PBS_URL.as_str(), [user])?;
-
-    let user = helpers::get_current_user().ok_or(anyhow::anyhow!("No user during PB processing"))?;
+pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
+    let url = dynfmt::SimpleCurlyFormat.format(TACHI_PBS_URL.as_str(), [user.tachi_id])?;
 
     let response: serde_json::Value = helpers::request_tachi("GET", url, &user.profile.api_key, None::<()>)?;
     let body = response["body"].as_object().ok_or(anyhow::anyhow!(

--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -27,7 +27,7 @@ pub fn process_pbs(user: &str, music: &Node) -> Result<Node> {
 
     let user = helpers::get_current_user().ok_or(anyhow::anyhow!("No user during PB processing"))?;
 
-    let response: serde_json::Value = helpers::request_tachi("GET", url, user.profile.config.api_key, None::<()>)?;
+    let response: serde_json::Value = helpers::request_tachi("GET", url, &user.profile.api_key, None::<()>)?;
     let body = response["body"].as_object().ok_or(anyhow::anyhow!(
         "Could not parse response body from Tachi PBs API"
     ))?;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
@@ -7,7 +8,7 @@ use std::path::Path;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Configuration {
     pub general: GeneralConfiguration,
-    pub cards: CardsConfiguration,
+    pub cards: HashMap<String, CardConfiguration>,
     pub tachi: TachiConfiguration,
 }
 
@@ -45,16 +46,16 @@ fn default_timeout() -> u64 {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CardsConfiguration {
-    #[serde(default)]
-    pub whitelist: Vec<String>,
+pub struct CardConfiguration {
+    pub api_key: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TachiConfiguration {
+    // TODO: it could be useful to move base_url to CardConfiguration as well
+    //       in case different users want different Tachi instances
     pub base_url: String,
     pub status: String,
     pub import: String,
     pub pbs: String,
-    pub api_key: String,
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -8,7 +8,10 @@ use std::path::Path;
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Configuration {
     pub general: GeneralConfiguration,
-    pub cards: HashMap<String, CardConfiguration>,
+    #[serde(default)]
+    pub cards: Option<CardsConfiguration>,
+    #[serde(default)]
+    pub profiles: HashMap<String, ProfileConfiguration>,
     pub tachi: TachiConfiguration,
 }
 
@@ -46,16 +49,31 @@ fn default_timeout() -> u64 {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct CardConfiguration {
+pub struct CardsConfiguration {
+    #[serde(default)]
+    pub whitelist: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ProfileConfiguration {
+    pub cards: Vec<String>,
     pub api_key: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Profile {
+    pub name: String,
+    pub config: ProfileConfiguration,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TachiConfiguration {
-    // TODO: it could be useful to move base_url to CardConfiguration as well
+    // TODO: it could be useful to move base_url to ProfileConfiguration as well
     //       in case different users want different Tachi instances
     pub base_url: String,
     pub status: String,
     pub import: String,
     pub pbs: String,
+    #[serde(default)]
+    pub api_key: Option<String>,
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -61,12 +61,6 @@ pub struct ProfileConfiguration {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Profile {
-    pub name: String,
-    pub config: ProfileConfiguration,
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TachiConfiguration {
     // TODO: it could be useful to move base_url to ProfileConfiguration as well
     //       in case different users want different Tachi instances

--- a/src/handlers/save.rs
+++ b/src/handlers/save.rs
@@ -23,7 +23,7 @@ pub fn process_save(save: GameSave) -> Result<()> {
         scores: vec![],
     };
 
-    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.card_config.api_key, Some(import))?;
+    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.profile.config.api_key, Some(import))?;
     info!("Successfully updated class for card {0}", user.card_id);
 
     Ok(())

--- a/src/handlers/save.rs
+++ b/src/handlers/save.rs
@@ -1,6 +1,6 @@
 use crate::types::game::GameSave;
 use crate::types::tachi::{Import, ImportClasses, SkillLevel};
-use crate::{helpers, CONFIGURATION, TACHI_IMPORT_URL};
+use crate::{helpers, TACHI_IMPORT_URL};
 use anyhow::Result;
 use log::info;
 
@@ -9,17 +9,9 @@ pub fn process_save(save: GameSave) -> Result<()> {
         info!("Guest play, skipping class update");
         return Ok(());
     }
-    let card = if let Some(card) = helpers::get_current_card_id() {
-        if !CONFIGURATION.cards.whitelist.is_empty()
-            && !CONFIGURATION.cards.whitelist.contains(&card)
-        {
-            info!("Card {card} is not whitelisted, skipping class update");
-            return Ok(());
-        }
 
-        card
-    } else {
-        info!("Card ID is not set, skipping class update");
+    let Some(user) = helpers::get_current_user() else {
+        info!("User is not set, skipping class update");
         return Ok(());
     };
 
@@ -31,8 +23,8 @@ pub fn process_save(save: GameSave) -> Result<()> {
         scores: vec![],
     };
 
-    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), Some(import))?;
-    info!("Successfully updated class for card {card}");
+    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.card_config.api_key, Some(import))?;
+    info!("Successfully updated class for card {0}", user.card_id);
 
     Ok(())
 }

--- a/src/handlers/save.rs
+++ b/src/handlers/save.rs
@@ -24,7 +24,7 @@ pub fn process_save(save: GameSave) -> Result<()> {
     };
 
     helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
-    info!("Successfully updated class for card {0}", user.card_id);
+    info!("Successfully updated class for card {}", user.card_id);
 
     Ok(())
 }

--- a/src/handlers/save.rs
+++ b/src/handlers/save.rs
@@ -23,7 +23,7 @@ pub fn process_save(save: GameSave) -> Result<()> {
         scores: vec![],
     };
 
-    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.profile.config.api_key, Some(import))?;
+    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
     info!("Successfully updated class for card {0}", user.card_id);
 
     Ok(())

--- a/src/handlers/scores.rs
+++ b/src/handlers/scores.rs
@@ -1,6 +1,6 @@
 use crate::types::game::GameScores;
 use crate::types::tachi::{HitMeta, Import, ImportScore, Judgements, TachiDifficulty, TachiLamp};
-use crate::{helpers, CONFIGURATION, TACHI_IMPORT_URL};
+use crate::{helpers, TACHI_IMPORT_URL};
 use anyhow::Result;
 use either::Either;
 use log::info;
@@ -10,17 +10,9 @@ pub fn process_scores(scores: GameScores) -> Result<()> {
         info!("Guest play, skipping score(s) submission");
         return Ok(());
     }
-    let card = if let Some(card) = helpers::get_current_card_id() {
-        if !CONFIGURATION.cards.whitelist.is_empty()
-            && !CONFIGURATION.cards.whitelist.contains(&card)
-        {
-            info!("Card {card} is not whitelisted, skipping score(s) submission");
-            return Ok(());
-        }
 
-        card
-    } else {
-        info!("Card ID is not set, skipping score(s) submission");
+    let Some(user) = helpers::get_current_user() else {
+        info!("User is not set, skipping score(s) submission");
         return Ok(());
     };
 
@@ -68,8 +60,8 @@ pub fn process_scores(scores: GameScores) -> Result<()> {
         scores,
     };
 
-    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), Some(import))?;
-    info!("Successfully imported score(s) for card {card}");
+    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.card_config.api_key, Some(import))?;
+    info!("Successfully imported score(s) for card {0}", user.card_id);
 
     Ok(())
 }

--- a/src/handlers/scores.rs
+++ b/src/handlers/scores.rs
@@ -60,7 +60,7 @@ pub fn process_scores(scores: GameScores) -> Result<()> {
         scores,
     };
 
-    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.card_config.api_key, Some(import))?;
+    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.profile.config.api_key, Some(import))?;
     info!("Successfully imported score(s) for card {0}", user.card_id);
 
     Ok(())

--- a/src/handlers/scores.rs
+++ b/src/handlers/scores.rs
@@ -61,7 +61,7 @@ pub fn process_scores(scores: GameScores) -> Result<()> {
     };
 
     helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
-    info!("Successfully imported score(s) for card {0}", user.card_id);
+    info!("Successfully imported score(s) for card {}", user.card_id);
 
     Ok(())
 }

--- a/src/handlers/scores.rs
+++ b/src/handlers/scores.rs
@@ -60,7 +60,7 @@ pub fn process_scores(scores: GameScores) -> Result<()> {
         scores,
     };
 
-    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), user.profile.config.api_key, Some(import))?;
+    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
     info!("Successfully imported score(s) for card {0}", user.card_id);
 
     Ok(())

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -78,7 +78,7 @@ pub fn get_current_user() -> Option<User> {
         error!("Current user RwLock is poisoned: {err:#}");
         err.into_inner()
     });
-    
+
     guard.clone()
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,5 @@
-use crate::mikado::CURRENT_CARD_ID;
+use crate::configuration::CardConfiguration;
+use crate::mikado::{CURRENT_USER, User};
 use crate::sys::{property_node_refer, NodeType};
 use crate::CONFIGURATION;
 use anyhow::Result;
@@ -19,6 +20,7 @@ pub fn request_agent() -> ureq::Agent {
 fn request<T>(
     method: impl AsRef<str>,
     url: impl AsRef<str>,
+    key: impl AsRef<str>,
     body: Option<T>,
 ) -> Result<ureq::Response>
 where
@@ -30,7 +32,7 @@ where
     let url = url.as_ref();
     debug!("{method} request to {url} with body: {body:#?}");
 
-    let authorization = format!("Bearer {}", CONFIGURATION.tachi.api_key);
+    let authorization = format!("Bearer {}", key.as_ref());
     let request = agent
         .request(method, url)
         .set("Authorization", authorization.as_str());
@@ -43,11 +45,11 @@ where
     Ok(response)
 }
 
-pub fn call_tachi<T>(method: impl AsRef<str>, url: impl AsRef<str>, body: Option<T>) -> Result<()>
+pub fn call_tachi<T>(method: impl AsRef<str>, url: impl AsRef<str>, key: impl AsRef<str>, body: Option<T>) -> Result<()>
 where
     T: Serialize + Debug,
 {
-    let response = request(method, url, body)?;
+    let response = request(method, url, key, body)?;
     let response: serde_json::Value = response.into_json()?;
     debug!("Tachi API response: {response:#?}");
 
@@ -57,40 +59,31 @@ where
 pub fn request_tachi<T, R>(
     method: impl AsRef<str>,
     url: impl AsRef<str>,
+    key: impl AsRef<str>,
     body: Option<T>,
 ) -> Result<R>
 where
     T: Serialize + Debug,
     R: for<'de> Deserialize<'de> + Debug,
 {
-    let response = request(method, url, body)?;
+    let response = request(method, url, key, body)?;
     let response = response.into_json()?;
     debug!("Tachi API response: {response:#?}");
 
     Ok(response)
 }
 
-pub fn get_current_card_id() -> Option<String> {
-    let guard = CURRENT_CARD_ID.read().unwrap_or_else(|err| {
-        error!("Current card ID RwLock is poisoned: {err:#}");
+pub fn get_current_user() -> Option<User> {
+    let guard = CURRENT_USER.read().unwrap_or_else(|err| {
+        error!("Current user RwLock is poisoned: {err:#}");
         err.into_inner()
     });
-
+    
     guard.clone()
 }
 
-pub fn is_current_card_id_whitelisted() -> bool {
-    if let Some(card) = get_current_card_id() {
-        if !CONFIGURATION.cards.whitelist.is_empty()
-            && !CONFIGURATION.cards.whitelist.contains(&card)
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    false
+pub fn get_card_config(card: impl AsRef<str>) -> Option<CardConfiguration> {
+    CONFIGURATION.cards.get(card.as_ref()).or(CONFIGURATION.cards.get("default")).cloned()
 }
 
 pub unsafe fn read_node_str(node: *const (), path: *const c_char, length: usize) -> Option<String> {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,5 +1,5 @@
-use crate::configuration::{Profile, ProfileConfiguration};
-use crate::mikado::{User, CURRENT_USER};
+use crate::mikado::CURRENT_USER;
+use crate::types::user::{Profile, User};
 use crate::sys::{property_node_refer, NodeType};
 use crate::{CARD_PROFILES, CONFIGURATION};
 use anyhow::Result;
@@ -93,14 +93,11 @@ pub fn get_profile(card: impl AsRef<str>) -> Option<Profile> {
             let api_key = CONFIGURATION.tachi.api_key.as_ref()?;
 
             let is_whitelisted = cards_config.whitelist.is_empty()
-                || cards_config.whitelist.contains(&card.as_ref().to_string());
+                || cards_config.whitelist.iter().any(|c| c == card.as_ref());
 
             is_whitelisted.then(|| Profile {
                 name: "default".to_string(),
-                config: ProfileConfiguration {
-                    api_key: api_key.to_string(),
-                    cards: cards_config.whitelist.clone(),
-                },
+                api_key: api_key.clone(),
             })
         })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,8 @@ mod types;
 
 use std::collections::HashMap;
 
-use crate::configuration::Profile;
 use crate::log::Logger;
+use crate::types::user::Profile;
 use crate::mikado::{hook_init, hook_release};
 use ::log::{error, info, warn};
 use configuration::Configuration;
@@ -35,10 +35,19 @@ lazy_static! {
 
         for (profile_name, profile_config) in &CONFIGURATION.profiles {
             for card in &profile_config.cards {
-                if let Some(existing_profile) = cards.get(card) {
+                if let Some(cards_config) = &CONFIGURATION.cards {
+                    if !cards_config.whitelist.is_empty() && cards_config.whitelist.contains(card) {
+                        warn!(
+                            "Card {} is in the default [cards] whitelist and also assigned to profile \"{}\". The profile assignment will be ignored. Remove it from the [cards] whitelist if you want it to use the profile.",
+                            card, profile_name
+                        );
+                        continue;
+                    }
+                }
+                if let Some(existing_profile) = cards.get(card.as_str()) {
                     warn!(
                         "Card {} is already assigned to profile \"{}\" but appears again in profile \"{}\". Ignoring.",
-                        card, &existing_profile.name, &profile_name
+                        card, existing_profile.name, profile_name
                     );
                     continue;
                 }
@@ -46,7 +55,7 @@ lazy_static! {
                     card.to_string(),
                     Profile {
                         name: profile_name.clone(),
-                        config: profile_config.clone(),
+                        api_key: profile_config.api_key.clone(),
                     },
                 );
             }

--- a/src/mikado.rs
+++ b/src/mikado.rs
@@ -338,7 +338,7 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
         });
 
         if let Ok(mut guard) = CURRENT_USER.write() {
-            let user = tachi_id.and_then(|tachi_id| {
+            *guard = tachi_id.and_then(|tachi_id| {
                 profile.map(|profile| {
                     info!("Setting current profile to \"{}\": card is {}, tachi is {}", &profile.name, card_id, tachi_id);
                     User {
@@ -348,8 +348,6 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
                     }
                 })
             });
-
-            *guard = user;
         } else {
             warn!("Could not acquire write lock on current user");
         }

--- a/src/mikado.rs
+++ b/src/mikado.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{OnceLock, RwLock};
 
 use anyhow::Result;
@@ -6,9 +6,9 @@ use bytes::Bytes;
 use kbinxml::{CompressionType, EncodingType, Node, Options, Value};
 use log::{debug, error, info, warn};
 
+use crate::configuration::CardConfiguration;
 use crate::handlers::save::process_save;
 use crate::handlers::scores::process_scores;
-use crate::helpers::is_current_card_id_whitelisted;
 use crate::sys::{
     property_clear_error, property_mem_write, property_node_name, property_node_refer,
     property_query_size, property_search, property_set_flag, NodeType,
@@ -17,8 +17,14 @@ use crate::types::game::Property;
 use crate::types::GameProperties;
 use crate::{helpers, CONFIGURATION, TACHI_STATUS_URL};
 
-pub static USER: AtomicU64 = AtomicU64::new(0);
-pub static CURRENT_CARD_ID: RwLock<Option<String>> = RwLock::new(None);
+#[derive(Clone)]
+pub struct User {
+    pub tachi_id: u64,
+    pub card_id: String,
+    pub card_config: CardConfiguration,
+}
+
+pub static CURRENT_USER: RwLock<Option<User>> = RwLock::new(None);
 pub static GAME_PROPERTIES: OnceLock<GameProperties> = OnceLock::new();
 
 pub fn hook_init(ea3_node: *const ()) -> Result<()> {
@@ -46,15 +52,6 @@ pub fn hook_init(ea3_node: *const ()) -> Result<()> {
         error!("Failure to set game properties, hook will not be enabled");
         return Ok(());
     }
-
-    // Try to reach Tachi API
-    let response: serde_json::Value =
-        helpers::request_tachi("GET", TACHI_STATUS_URL.as_str(), None::<()>)?;
-    let user = response["body"]["whoami"]
-        .as_u64()
-        .ok_or(anyhow::anyhow!("Couldn't parse user from Tachi response"))?;
-    USER.store(user, Ordering::Relaxed);
-    info!("Tachi API successfully reached, user {user}");
 
     // Initializing function detours
     crochet::enable!(property_destroy_hook)
@@ -187,7 +184,7 @@ pub unsafe fn property_mem_read_hook_wrapped(
 
             Ok(response)
         })())
-    } else if is_current_card_id_whitelisted()
+    } else if helpers::get_current_user().is_some()
         && load
             .then(|| root.pointer(&["game", "code"]))
             .flatten()
@@ -208,10 +205,10 @@ pub unsafe fn property_mem_read_hook_wrapped(
             Ok(response)
         })())
     } else if let Some(music) = load_m.then(|| root.pointer(&["game", "music"])).flatten() {
-        if is_current_card_id_whitelisted() {
+        if let Some(user) = helpers::get_current_user() {
             Some((|| {
-                let user = USER.load(Ordering::SeqCst).to_string();
-                let response = crate::cloudlink::process_pbs(user.as_str(), music)?;
+                let response =
+                    crate::cloudlink::process_pbs(user.tachi_id.to_string().as_str(), music)?;
                 let response = build_response(&original_signature, response, encoding)?;
                 LOAD_M.store(false, Ordering::Relaxed);
 
@@ -301,7 +298,7 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
             return call_original!(property);
         }
 
-        let cardid = {
+        let card_id = {
             let result = std::str::from_utf8(&buffer[..32]);
             if let Err(err) = result {
                 error!("Could not convert buffer to string: {err:#}");
@@ -311,11 +308,50 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
             result.unwrap().replace('\0', "")
         };
 
-        if let Ok(mut guard) = CURRENT_CARD_ID.write() {
-            debug!("Set current card id to {cardid}");
-            *guard = Some(cardid);
+        let card_config = helpers::get_card_config(&card_id);
+        if card_config.is_none() {
+            warn!("No config for card {card_id}");
+        }
+
+        // Try to reach Tachi API
+        fn get_tachi_user(key: impl AsRef<str>) -> Result<u64> {
+            let response: serde_json::Value =
+                helpers::request_tachi("GET", TACHI_STATUS_URL.as_str(), key, None::<()>)?;
+
+            response["body"]["whoami"]
+                .as_u64()
+                .ok_or(anyhow::anyhow!("Couldn't parse user from Tachi response"))
+        }
+
+        let tachi_id = card_config.as_ref().and_then(|card_config| {
+            let key = card_config.api_key.clone();
+            match get_tachi_user(key) {
+                Ok(user) => {
+                    debug!("Tachi API reached, set current user to {user}");
+                    Some(user)
+                }
+                Err(e) => {
+                    warn!("did not set Tachi user: {e}");
+                    None
+                }
+            }
+        });
+
+        if let Ok(mut guard) = CURRENT_USER.write() {
+            let user = tachi_id.and_then(|tachi_id| {
+                card_config.map(|card_config| {
+                    info!("Setting current user: card is {card_id}, tachi is {tachi_id}");
+                    User {
+                        tachi_id,
+                        card_id,
+                        card_config,
+                    }
+                })
+            });
+
+            *guard = user;
         } else {
-            warn!("Could not acquire write lock on current card id");
+            warn!("Could not acquire write lock on current user");
         }
 
         return call_original!(property);

--- a/src/mikado.rs
+++ b/src/mikado.rs
@@ -201,7 +201,7 @@ pub unsafe fn property_mem_read_hook_wrapped(
         if let Some(user) = helpers::get_current_user() {
             Some((|| {
                 let response =
-                    crate::cloudlink::process_pbs(user.tachi_id.to_string().as_str(), music)?;
+                    crate::cloudlink::process_pbs(&user, music)?;
                 let response = build_response(&original_signature, response, encoding)?;
                 LOAD_M.store(false, Ordering::Relaxed);
 

--- a/src/mikado.rs
+++ b/src/mikado.rs
@@ -6,7 +6,6 @@ use bytes::Bytes;
 use kbinxml::{CompressionType, EncodingType, Node, Options, Value};
 use log::{debug, error, info, warn};
 
-use crate::configuration::Profile;
 use crate::handlers::save::process_save;
 use crate::handlers::scores::process_scores;
 use crate::sys::{
@@ -14,15 +13,9 @@ use crate::sys::{
     property_query_size, property_search, property_set_flag, NodeType,
 };
 use crate::types::game::Property;
+use crate::types::user::User;
 use crate::types::GameProperties;
 use crate::{helpers, CONFIGURATION, TACHI_STATUS_URL};
-
-#[derive(Clone)]
-pub struct User {
-    pub tachi_id: u64,
-    pub card_id: String,
-    pub profile: Profile,
-}
 
 pub static CURRENT_USER: RwLock<Option<User>> = RwLock::new(None);
 pub static GAME_PROPERTIES: OnceLock<GameProperties> = OnceLock::new();
@@ -324,8 +317,7 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
         }
 
         let tachi_id = profile.as_ref().and_then(|profile| {
-            let key = profile.config.api_key.clone();
-            match get_tachi_user(key) {
+            match get_tachi_user(&profile.api_key) {
                 Ok(user) => {
                     debug!("Tachi API reached, set current user to {user}");
                     Some(user)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::{Display, Formatter};
 pub mod cloudlink;
 pub mod game;
 pub mod tachi;
+pub mod user;
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GameProperties {

--- a/src/types/user.rs
+++ b/src/types/user.rs
@@ -1,0 +1,12 @@
+#[derive(Debug, Clone)]
+pub struct Profile {
+    pub name: String,
+    pub api_key: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct User {
+    pub tachi_id: u64,
+    pub card_id: String,
+    pub profile: Profile,
+}


### PR DESCRIPTION
Adds multi-user support by 1. allowing the config to specify distinct API keys for individual cards and 2. setting the Tachi user ID and API key alongside the card ID on every `cardmng.inquire`.

This involves a nontrivial breaking change in the config format: I replace the card whitelist with card-specific API keys and an optional “default” key. You can accomplish the same behavior as the previous whitelist system, but it will be more verbose if for whatever reason you have lots of cards for one Tachi account.

I’m by no means a professional, but I’ve done a little trivial testing (shared setup, two sessions on two different cards linked to two different Tachi accounts, no reboot inbetween) and it seems to work for me.

Let me know if you’d like any changes made to the approach :)