### PR TITLE
Implement Nabla support

### DIFF
--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -129,6 +129,13 @@ pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
             + 1;
         let grade = if grade >= 11 { 10 } else { grade };
 
+        let ex_score = match pb["scoreData"]["optional"]["exScore"].clone() {
+            serde_json::Value::Null => {
+                0
+            }
+            value => value.as_u64().unwrap_or(0),
+        };
+
         let entry = scores.entry(*chart);
         match entry {
             Entry::Occupied(mut entry) => {
@@ -136,9 +143,10 @@ pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
                 *base_score.cloud_score_mut() = score as u32;
                 *base_score.cloud_clear_mut() = lamp as u32;
                 *base_score.cloud_grade_mut() = grade as u32;
+                *base_score.cloud_ex_score_mut() = ex_score as u32;
             }
             Entry::Vacant(entry) => {
-                let score = Score::from_cloud(score as u32, lamp as u8, grade as u8);
+                let score = Score::from_cloud(score as u32, lamp as u8, grade as u8, ex_score as u32);
                 entry.insert(score);
             }
         }

--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -1,7 +1,7 @@
 mod ext;
 
 use crate::types::cloudlink::{Chart, Score};
-use crate::types::tachi::{TachiDifficulty, TachiLamp, TachiLampNabla};
+use crate::types::tachi::{TachiDifficulty, TachiLamp};
 use crate::types::user::User;
 use crate::{helpers, mikado, TACHI_PBS_URL};
 use anyhow::Result;
@@ -60,6 +60,9 @@ pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
         })
         .collect::<Result<HashMap<&str, Chart>>>()?;
 
+    let is_nabla = mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default();
+    let has_maxxive = mikado::GAME_PROPERTIES.get().map(|p| p.has_maxxive_support()).unwrap_or_default();
+
     let mut scores = HashMap::with_capacity(music.children().len() + pbs.len());
     for pb in music.children() {
         let score = pb
@@ -76,7 +79,7 @@ pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
                 song_id,
                 difficulty,
             };
-            let score = Score::from_slice(value)?;
+            let score = Score::from_slice(is_nabla, value)?;
             scores.insert(chart, score);
         }
     }
@@ -92,35 +95,13 @@ pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
             "Could not parse PB score from Tachi PBs API"
         ))?;
 
-        let lamp: u32;
-        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            lamp = match serde_json::from_value::<TachiLampNabla>(pb["scoreData"]["lamp"].clone()) {
-                Ok(TachiLampNabla::MaxxiveClear)
-                    if !mikado::GAME_PROPERTIES
-                        .get()
-                        .map(|p| p.has_maxxive_support())
-                        .unwrap_or_default() =>
-                {
-                    TachiLampNabla::ExcessiveClear.into()
-                }
-                Ok(lamp) => lamp.into(),
-                Err(_) => 0,
-            };
-        } else {
-            lamp = match serde_json::from_value::<TachiLamp>(pb["scoreData"]["lamp"].clone()) {
-                Ok(TachiLamp::MaxxiveClear)
-                    if !mikado::GAME_PROPERTIES
-                        .get()
-                        .map(|p| p.has_maxxive_support())
-                        .unwrap_or_default() =>
-                {
-                    TachiLamp::ExcessiveClear.into()
-                }
-                Ok(lamp) => lamp.into(),
-                Err(_) => 0,
-            };
-        }
-        
+        let lamp = match serde_json::from_value::<TachiLamp>(pb["scoreData"]["lamp"].clone()) {
+            Ok(TachiLamp::MaxxiveClear) if !has_maxxive => TachiLamp::ExcessiveClear,
+            Ok(lamp) => lamp,
+            Err(_) => TachiLamp::Failed,
+        };
+        let lamp = if is_nabla { lamp.to_nabla_index() } else { lamp.to_eg_index() };
+
         let grade = pb["scoreData"]["enumIndexes"]["grade"]
             .as_u64()
             .ok_or(anyhow::anyhow!(
@@ -129,24 +110,21 @@ pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
             + 1;
         let grade = if grade >= 11 { 10 } else { grade };
 
-        let ex_score = match pb["scoreData"]["optional"]["exScore"].clone() {
-            serde_json::Value::Null => {
-                0
-            }
-            value => value.as_u64().unwrap_or(0),
-        };
+        let ex_score = pb["scoreData"]["optional"]["exScore"].as_u64().unwrap_or(0) as u32;
 
         let entry = scores.entry(*chart);
         match entry {
             Entry::Occupied(mut entry) => {
                 let base_score = entry.get_mut();
                 *base_score.cloud_score_mut() = score as u32;
-                *base_score.cloud_clear_mut() = lamp as u32;
+                *base_score.cloud_clear_mut() = lamp;
                 *base_score.cloud_grade_mut() = grade as u32;
-                *base_score.cloud_ex_score_mut() = ex_score as u32;
+                if let Some(ex) = base_score.cloud_ex_score_mut() {
+                    *ex = ex_score;
+                }
             }
             Entry::Vacant(entry) => {
-                let score = Score::from_cloud(score as u32, lamp as u8, grade as u8, ex_score as u32);
+                let score = Score::from_cloud(is_nabla, score as u32, lamp as u8, grade as u8, ex_score);
                 entry.insert(score);
             }
         }

--- a/src/cloudlink/mod.rs
+++ b/src/cloudlink/mod.rs
@@ -1,7 +1,7 @@
 mod ext;
 
 use crate::types::cloudlink::{Chart, Score};
-use crate::types::tachi::{TachiDifficulty, TachiLamp};
+use crate::types::tachi::{TachiDifficulty, TachiLamp, TachiLampNabla};
 use crate::types::user::User;
 use crate::{helpers, mikado, TACHI_PBS_URL};
 use anyhow::Result;
@@ -91,18 +91,36 @@ pub fn process_pbs(user: &User, music: &Node) -> Result<Node> {
         let score = pb["scoreData"]["score"].as_u64().ok_or(anyhow::anyhow!(
             "Could not parse PB score from Tachi PBs API"
         ))?;
-        let lamp: u32 = match serde_json::from_value::<TachiLamp>(pb["scoreData"]["lamp"].clone()) {
-            Ok(TachiLamp::MaxxiveClear)
-                if !mikado::GAME_PROPERTIES
-                    .get()
-                    .map(|p| p.has_maxxive_support())
-                    .unwrap_or_default() =>
-            {
-                TachiLamp::ExcessiveClear.into()
-            }
-            Ok(lamp) => lamp.into(),
-            Err(_) => 0,
-        };
+
+        let lamp: u32;
+        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+            lamp = match serde_json::from_value::<TachiLampNabla>(pb["scoreData"]["lamp"].clone()) {
+                Ok(TachiLampNabla::MaxxiveClear)
+                    if !mikado::GAME_PROPERTIES
+                        .get()
+                        .map(|p| p.has_maxxive_support())
+                        .unwrap_or_default() =>
+                {
+                    TachiLampNabla::ExcessiveClear.into()
+                }
+                Ok(lamp) => lamp.into(),
+                Err(_) => 0,
+            };
+        } else {
+            lamp = match serde_json::from_value::<TachiLamp>(pb["scoreData"]["lamp"].clone()) {
+                Ok(TachiLamp::MaxxiveClear)
+                    if !mikado::GAME_PROPERTIES
+                        .get()
+                        .map(|p| p.has_maxxive_support())
+                        .unwrap_or_default() =>
+                {
+                    TachiLamp::ExcessiveClear.into()
+                }
+                Ok(lamp) => lamp.into(),
+                Err(_) => 0,
+            };
+        }
+        
         let grade = pb["scoreData"]["enumIndexes"]["grade"]
             .as_u64()
             .ok_or(anyhow::anyhow!(

--- a/src/handlers/scores.rs
+++ b/src/handlers/scores.rs
@@ -1,5 +1,5 @@
 use crate::types::game::GameScores;
-use crate::types::tachi::{HitMeta, Import, ImportNabla, ImportScore, ImportScoreNabla, Judgements, TachiDifficulty, TachiLamp, TachiLampNabla};
+use crate::types::tachi::{HitMeta, Import, ImportScore, Judgements, TachiDifficulty, TachiLamp};
 use crate::{helpers, mikado, TACHI_IMPORT_URL};
 use anyhow::Result;
 use either::Either;
@@ -21,85 +21,53 @@ pub fn process_scores(scores: GameScores) -> Result<()> {
         Either::Right(tracks) => tracks,
     };
 
+    let is_nabla = mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default();
+
     let time_achieved = std::time::UNIX_EPOCH
         .elapsed()
         .map(|duration| duration.as_millis())
         .map_err(|err| anyhow::anyhow!("Could not get time from System {:#}", err))?;
-    if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-        let scores = tracks
-            .into_iter()
-            .map(|track| ImportScoreNabla {
-                score: track.score,
-                lamp: TachiLampNabla::from(track.clear_type),
-                match_type: "sdvxInGameID".to_string(),
-                identifier: track.music_id.to_string(),
-                difficulty: TachiDifficulty::from(track.music_type),
-                time_achieved,
-                judgements: Judgements {
-                    critical: track.critical,
-                    near: track.near,
-                    miss: track.error,
-                },
-                hit_meta: HitMeta {
-                    fast: track.judge[0],
-                    slow: track.judge[6],
-                    max_combo: track.max_chain,
-                    ex_score: if track.ex_score != 0 {
-                        Some(track.ex_score)
-                    } else {
-                        None
-                    },
-                    gauge: track.effective_rate as f32 / 100.0,
-                },
-            })
-            .collect();
 
-        let import = ImportNabla {
-            meta: Default::default(),
-            classes: None,
-            scores,
-        };
-
-        helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
-        info!("Successfully imported score(s) for card {}", user.card_id);
-    } else {
-        let scores = tracks
-            .into_iter()
-            .map(|track| ImportScore {
-                score: track.score,
-                lamp: TachiLamp::from(track.clear_type),
-                match_type: "sdvxInGameID".to_string(),
-                identifier: track.music_id.to_string(),
-                difficulty: TachiDifficulty::from(track.music_type),
-                time_achieved,
-                judgements: Judgements {
-                    critical: track.critical,
-                    near: track.near,
-                    miss: track.error,
+    let scores = tracks
+        .into_iter()
+        .map(|track| ImportScore {
+            score: track.score,
+            lamp: if is_nabla {
+                TachiLamp::from_nabla(track.clear_type)
+            } else {
+                TachiLamp::from_eg(track.clear_type)
+            },
+            match_type: "sdvxInGameID".to_string(),
+            identifier: track.music_id.to_string(),
+            difficulty: TachiDifficulty::from(track.music_type),
+            time_achieved,
+            judgements: Judgements {
+                critical: track.critical,
+                near: track.near,
+                miss: track.error,
+            },
+            hit_meta: HitMeta {
+                fast: track.judge[0],
+                slow: track.judge[6],
+                max_combo: track.max_chain,
+                ex_score: if track.ex_score != 0 {
+                    Some(track.ex_score)
+                } else {
+                    None
                 },
-                hit_meta: HitMeta {
-                    fast: track.judge[0],
-                    slow: track.judge[6],
-                    max_combo: track.max_chain,
-                    ex_score: if track.ex_score != 0 {
-                        Some(track.ex_score)
-                    } else {
-                        None
-                    },
-                    gauge: track.effective_rate as f32 / 100.0,
-                },
-            })
-            .collect();
+                gauge: track.effective_rate as f32 / 100.0,
+            },
+        })
+        .collect();
 
-        let import = Import {
-            meta: Default::default(),
-            classes: None,
-            scores,
-        };
+    let import = Import {
+        meta: Default::default(),
+        classes: None,
+        scores,
+    };
 
-        helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
-        info!("Successfully imported score(s) for card {}", user.card_id);
-    }
+    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
+    info!("Successfully imported score(s) for card {}", user.card_id);
 
     Ok(())
 }

--- a/src/handlers/scores.rs
+++ b/src/handlers/scores.rs
@@ -1,6 +1,6 @@
 use crate::types::game::GameScores;
-use crate::types::tachi::{HitMeta, Import, ImportScore, Judgements, TachiDifficulty, TachiLamp};
-use crate::{helpers, TACHI_IMPORT_URL};
+use crate::types::tachi::{HitMeta, Import, ImportNabla, ImportScore, ImportScoreNabla, Judgements, TachiDifficulty, TachiLamp, TachiLampNabla};
+use crate::{helpers, mikado, TACHI_IMPORT_URL};
 use anyhow::Result;
 use either::Either;
 use log::info;
@@ -25,43 +25,81 @@ pub fn process_scores(scores: GameScores) -> Result<()> {
         .elapsed()
         .map(|duration| duration.as_millis())
         .map_err(|err| anyhow::anyhow!("Could not get time from System {:#}", err))?;
-
-    let scores = tracks
-        .into_iter()
-        .map(|track| ImportScore {
-            score: track.score,
-            lamp: TachiLamp::from(track.clear_type),
-            match_type: "sdvxInGameID".to_string(),
-            identifier: track.music_id.to_string(),
-            difficulty: TachiDifficulty::from(track.music_type),
-            time_achieved,
-            judgements: Judgements {
-                critical: track.critical,
-                near: track.near,
-                miss: track.error,
-            },
-            hit_meta: HitMeta {
-                fast: track.judge[0],
-                slow: track.judge[6],
-                max_combo: track.max_chain,
-                ex_score: if track.ex_score != 0 {
-                    Some(track.ex_score)
-                } else {
-                    None
+    if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+        let scores = tracks
+            .into_iter()
+            .map(|track| ImportScoreNabla {
+                score: track.score,
+                lamp: TachiLampNabla::from(track.clear_type),
+                match_type: "sdvxInGameID".to_string(),
+                identifier: track.music_id.to_string(),
+                difficulty: TachiDifficulty::from(track.music_type),
+                time_achieved,
+                judgements: Judgements {
+                    critical: track.critical,
+                    near: track.near,
+                    miss: track.error,
                 },
-                gauge: track.effective_rate as f32 / 100.0,
-            },
-        })
-        .collect();
+                hit_meta: HitMeta {
+                    fast: track.judge[0],
+                    slow: track.judge[6],
+                    max_combo: track.max_chain,
+                    ex_score: if track.ex_score != 0 {
+                        Some(track.ex_score)
+                    } else {
+                        None
+                    },
+                    gauge: track.effective_rate as f32 / 100.0,
+                },
+            })
+            .collect();
 
-    let import = Import {
-        meta: Default::default(),
-        classes: None,
-        scores,
-    };
+        let import = ImportNabla {
+            meta: Default::default(),
+            classes: None,
+            scores,
+        };
 
-    helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
-    info!("Successfully imported score(s) for card {}", user.card_id);
+        helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
+        info!("Successfully imported score(s) for card {}", user.card_id);
+    } else {
+        let scores = tracks
+            .into_iter()
+            .map(|track| ImportScore {
+                score: track.score,
+                lamp: TachiLamp::from(track.clear_type),
+                match_type: "sdvxInGameID".to_string(),
+                identifier: track.music_id.to_string(),
+                difficulty: TachiDifficulty::from(track.music_type),
+                time_achieved,
+                judgements: Judgements {
+                    critical: track.critical,
+                    near: track.near,
+                    miss: track.error,
+                },
+                hit_meta: HitMeta {
+                    fast: track.judge[0],
+                    slow: track.judge[6],
+                    max_combo: track.max_chain,
+                    ex_score: if track.ex_score != 0 {
+                        Some(track.ex_score)
+                    } else {
+                        None
+                    },
+                    gauge: track.effective_rate as f32 / 100.0,
+                },
+            })
+            .collect();
+
+        let import = Import {
+            meta: Default::default(),
+            classes: None,
+            scores,
+        };
+
+        helpers::call_tachi("POST", TACHI_IMPORT_URL.as_str(), &user.profile.api_key, Some(import))?;
+        info!("Successfully imported score(s) for card {}", user.card_id);
+    }
 
     Ok(())
 }

--- a/src/mikado.rs
+++ b/src/mikado.rs
@@ -353,32 +353,20 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
         return call_original!(property);
     }
 
-    // Super ugly solution to allow both EG and Nabla support
-    let prefix;
-
-    if GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-        prefix = "sv7";
-    } else {
-        prefix = "sv6";
-    }
-
-    let load_m_method = format!("{prefix}_load_m");
-    let common_method = format!("{prefix}_common");
-    let load_method = format!("{prefix}_load");
-    let save_m_method = format!("{prefix}_save_m");
-    let save_method = format!("{prefix}_save");
+    let prefix = GAME_PROPERTIES.get().map(|p| p.method_prefix()).unwrap_or("sv6");
+    let method = method.strip_prefix(prefix).and_then(|s| s.strip_prefix('_')).unwrap_or("");
 
     if CONFIGURATION.general.inject_cloud_pbs {
-        if method == load_m_method {
+        if method == "load_m" {
             LOAD_M.store(true, Ordering::Relaxed);
-        } else if method == common_method {
+        } else if method == "common" {
             COMMON.store(true, Ordering::Relaxed);
-        } else if method == load_method {
+        } else if method == "load" {
             LOAD.store(true, Ordering::Relaxed);
         }
     }
 
-    if method != save_m_method && (!CONFIGURATION.general.export_class || method != save_method) {
+    if method != "save_m" && (!CONFIGURATION.general.export_class || method != "save") {
         return call_original!(property);
     }
 
@@ -409,24 +397,20 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
     };
 
     debug!("Processing property: {property_str}");
-    if let Err(err) = match method.as_str() {
-        _ if method.as_str() == save_m_method => serde_json::from_str::<Property>(property_str)
+    if let Err(err) = match method {
+        "save_m" => serde_json::from_str::<Property>(property_str)
             .map_err(|err| anyhow::anyhow!("Could not parse property: {err:#}"))
             .and_then(|prop| {
                 process_scores(
-                    prop.call
-                        .game
-                        .left()
+                    prop.call.game.left()
                         .ok_or(anyhow::anyhow!("Could not process scores property"))?,
                 )
             }),
-        _ if method.as_str() == save_method => serde_json::from_str::<Property>(property_str)
+        "save" => serde_json::from_str::<Property>(property_str)
             .map_err(|err| anyhow::anyhow!("Could not parse property: {err:#}"))
             .and_then(|prop| {
                 process_save(
-                    prop.call
-                        .game
-                        .right()
+                    prop.call.game.right()
                         .ok_or(anyhow::anyhow!("Could not process save property"))?,
                 )
             }),

--- a/src/mikado.rs
+++ b/src/mikado.rs
@@ -46,6 +46,12 @@ pub fn hook_init(ea3_node: *const ()) -> Result<()> {
         return Ok(());
     }
 
+    if GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+        debug!("Nabla detected, using Nabla method prefix 'sv7'");
+    } else {
+        debug!("EG detected, using EG method prefix 'sv6'");
+    }
+
     // Initializing function detours
     crochet::enable!(property_destroy_hook)
         .map_err(|err| anyhow::anyhow!("Could not enable function detour: {:#}", err))?;
@@ -347,17 +353,32 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
         return call_original!(property);
     }
 
+    // Super ugly solution to allow both EG and Nabla support
+    let prefix;
+
+    if GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+        prefix = "sv7";
+    } else {
+        prefix = "sv6";
+    }
+
+    let load_m_method = format!("{prefix}_load_m");
+    let common_method = format!("{prefix}_common");
+    let load_method = format!("{prefix}_load");
+    let save_m_method = format!("{prefix}_save_m");
+    let save_method = format!("{prefix}_save");
+
     if CONFIGURATION.general.inject_cloud_pbs {
-        if method == "sv6_load_m" {
+        if method == load_m_method {
             LOAD_M.store(true, Ordering::Relaxed);
-        } else if method == "sv6_common" {
+        } else if method == common_method {
             COMMON.store(true, Ordering::Relaxed);
-        } else if method == "sv6_load" {
+        } else if method == load_method {
             LOAD.store(true, Ordering::Relaxed);
         }
     }
 
-    if method != "sv6_save_m" && (!CONFIGURATION.general.export_class || method != "sv6_save") {
+    if method != save_m_method && (!CONFIGURATION.general.export_class || method != save_method) {
         return call_original!(property);
     }
 
@@ -389,7 +410,7 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
 
     debug!("Processing property: {property_str}");
     if let Err(err) = match method.as_str() {
-        "sv6_save_m" => serde_json::from_str::<Property>(property_str)
+        save_m_method => serde_json::from_str::<Property>(property_str)
             .map_err(|err| anyhow::anyhow!("Could not parse property: {err:#}"))
             .and_then(|prop| {
                 process_scores(
@@ -399,7 +420,7 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
                         .ok_or(anyhow::anyhow!("Could not process scores property"))?,
                 )
             }),
-        "sv6_save" => serde_json::from_str::<Property>(property_str)
+        save_method => serde_json::from_str::<Property>(property_str)
             .map_err(|err| anyhow::anyhow!("Could not parse property: {err:#}"))
             .and_then(|prop| {
                 process_save(

--- a/src/mikado.rs
+++ b/src/mikado.rs
@@ -410,7 +410,7 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
 
     debug!("Processing property: {property_str}");
     if let Err(err) = match method.as_str() {
-        save_m_method => serde_json::from_str::<Property>(property_str)
+        _ if method.as_str() == save_m_method => serde_json::from_str::<Property>(property_str)
             .map_err(|err| anyhow::anyhow!("Could not parse property: {err:#}"))
             .and_then(|prop| {
                 process_scores(
@@ -420,7 +420,7 @@ pub unsafe fn property_destroy_hook(property: *mut ()) -> i32 {
                         .ok_or(anyhow::anyhow!("Could not process scores property"))?,
                 )
             }),
-        save_method => serde_json::from_str::<Property>(property_str)
+        _ if method.as_str() == save_method => serde_json::from_str::<Property>(property_str)
             .map_err(|err| anyhow::anyhow!("Could not parse property: {err:#}"))
             .and_then(|prop| {
                 process_save(

--- a/src/types/cloudlink.rs
+++ b/src/types/cloudlink.rs
@@ -44,7 +44,7 @@ impl Score {
 
     pub fn cloud_score_mut(&mut self) -> &mut u32 {
         if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            &mut self.property[18]
+            &mut self.property_nabla[18]
         } else {
             &mut self.property[17]
         }
@@ -52,7 +52,7 @@ impl Score {
 
     pub fn cloud_clear_mut(&mut self) -> &mut u32 {
         if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            &mut self.property[20]
+            &mut self.property_nabla[20]
         } else {
             &mut self.property[18]
         }
@@ -60,7 +60,7 @@ impl Score {
 
     pub fn cloud_grade_mut(&mut self) -> &mut u32 {
         if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            &mut self.property[21]
+            &mut self.property_nabla[21]
         } else {
             &mut self.property[19]
         }

--- a/src/types/cloudlink.rs
+++ b/src/types/cloudlink.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use crate::{mikado};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct Chart {
@@ -7,75 +6,80 @@ pub struct Chart {
     pub difficulty: u8,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Score {
-    property: [u32; 21],
-    property_nabla: [u32; 26],
+#[derive(Debug, Clone, Copy)]
+pub enum Score {
+    ExceedGear([u32; 21]),
+    Nabla([u32; 26]),
 }
 
 impl Score {
-    pub fn from_cloud(score: u32, clear: u8, grade: u8, ex_score: u32) -> Self {
-        let mut ret = Self::default();
-        ret.property[17] = score;
-        ret.property[18] = clear as u32;
-        ret.property[19] = grade as u32;
-
-        ret.property_nabla[18] = score;
-        ret.property_nabla[19] = ex_score;
-        ret.property_nabla[20] = clear as u32;
-        ret.property_nabla[21] = grade as u32;
-
-        ret
+    pub fn from_cloud(is_nabla: bool, score: u32, clear: u8, grade: u8, ex_score: u32) -> Self {
+        if is_nabla {
+            let mut arr = [0u32; 26];
+            arr[18] = score;
+            arr[19] = ex_score;
+            arr[20] = clear as u32;
+            arr[21] = grade as u32;
+            Score::Nabla(arr)
+        } else {
+            let mut arr = [0u32; 21];
+            arr[17] = score;
+            arr[18] = clear as u32;
+            arr[19] = grade as u32;
+            Score::ExceedGear(arr)
+        }
     }
 
-    pub fn from_slice(vec: &[u32]) -> Result<Self> {
-        if vec.len() < 21 {
-            return Err(anyhow::anyhow!("Could not parse score"));
-        }
-        let mut ret = Self::default();
-        ret.property.copy_from_slice(&vec[..21]);
-        if vec.len() >= 26 {
-            ret.property_nabla.copy_from_slice(&vec[..26]);
+    pub fn from_slice(is_nabla: bool, vec: &[u32]) -> Result<Self> {
+        if is_nabla {
+            if vec.len() < 26 {
+                return Err(anyhow::anyhow!("Could not parse score"));
+            }
+            let mut arr = [0u32; 26];
+            arr.copy_from_slice(&vec[..26]);
+            Ok(Score::Nabla(arr))
         } else {
-            // populate only the first 21 elements when full nabla properties aren't present
-            ret.property_nabla[..21].copy_from_slice(&vec[..21]);
+            if vec.len() < 21 {
+                return Err(anyhow::anyhow!("Could not parse score"));
+            }
+            let mut arr = [0u32; 21];
+            arr.copy_from_slice(&vec[..21]);
+            Ok(Score::ExceedGear(arr))
         }
-        Ok(ret)
     }
 
     pub fn cloud_score_mut(&mut self) -> &mut u32 {
-        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            &mut self.property_nabla[18]
-        } else {
-            &mut self.property[17]
+        match self {
+            Score::ExceedGear(arr) => &mut arr[17],
+            Score::Nabla(arr) => &mut arr[18],
         }
     }
 
     pub fn cloud_clear_mut(&mut self) -> &mut u32 {
-        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            &mut self.property_nabla[20]
-        } else {
-            &mut self.property[18]
+        match self {
+            Score::ExceedGear(arr) => &mut arr[18],
+            Score::Nabla(arr) => &mut arr[20],
         }
     }
 
     pub fn cloud_grade_mut(&mut self) -> &mut u32 {
-        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            &mut self.property_nabla[21]
-        } else {
-            &mut self.property[19]
+        match self {
+            Score::ExceedGear(arr) => &mut arr[19],
+            Score::Nabla(arr) => &mut arr[21],
         }
     }
 
-    pub fn cloud_ex_score_mut(&mut self) -> &mut u32 {
-        &mut self.property_nabla[19]
+    pub fn cloud_ex_score_mut(&mut self) -> Option<&mut u32> {
+        match self {
+            Score::ExceedGear(_) => None,
+            Score::Nabla(arr) => Some(&mut arr[19]),
+        }
     }
 
     pub fn to_property(self) -> Vec<u32> {
-        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
-            return self.property_nabla.to_vec();
-        } else {
-            return self.property.to_vec();
+        match self {
+            Score::ExceedGear(arr) => arr.to_vec(),
+            Score::Nabla(arr) => arr.to_vec(),
         }
     }
 }

--- a/src/types/cloudlink.rs
+++ b/src/types/cloudlink.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use crate::{mikado};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub struct Chart {
@@ -9,6 +10,7 @@ pub struct Chart {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Score {
     property: [u32; 21],
+    property_nabla: [u32; 26],
 }
 
 impl Score {
@@ -17,6 +19,10 @@ impl Score {
         ret.property[17] = score;
         ret.property[18] = clear as u32;
         ret.property[19] = grade as u32;
+
+        ret.property_nabla[18] = score;
+        ret.property_nabla[20] = clear as u32;
+        ret.property_nabla[21] = grade as u32;
 
         ret
     }
@@ -27,23 +33,44 @@ impl Score {
         }
         let mut ret = Self::default();
         ret.property.copy_from_slice(&vec[..21]);
-
+        if vec.len() >= 26 {
+            ret.property_nabla.copy_from_slice(&vec[..26]);
+        } else {
+            // populate only the first 21 elements when full nabla properties aren't present
+            ret.property_nabla[..21].copy_from_slice(&vec[..21]);
+        }
         Ok(ret)
     }
 
     pub fn cloud_score_mut(&mut self) -> &mut u32 {
-        &mut self.property[17]
+        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+            &mut self.property[18]
+        } else {
+            &mut self.property[17]
+        }
     }
 
     pub fn cloud_clear_mut(&mut self) -> &mut u32 {
-        &mut self.property[18]
+        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+            &mut self.property[20]
+        } else {
+            &mut self.property[18]
+        }
     }
 
     pub fn cloud_grade_mut(&mut self) -> &mut u32 {
-        &mut self.property[19]
+        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+            &mut self.property[21]
+        } else {
+            &mut self.property[19]
+        }
     }
 
     pub fn to_property(self) -> Vec<u32> {
-        self.property.to_vec()
+        if mikado::GAME_PROPERTIES.get().map(|p| p.is_nabla()).unwrap_or_default() {
+            return self.property_nabla.to_vec();
+        } else {
+            return self.property.to_vec();
+        }
     }
 }

--- a/src/types/cloudlink.rs
+++ b/src/types/cloudlink.rs
@@ -14,13 +14,14 @@ pub struct Score {
 }
 
 impl Score {
-    pub fn from_cloud(score: u32, clear: u8, grade: u8) -> Self {
+    pub fn from_cloud(score: u32, clear: u8, grade: u8, ex_score: u32) -> Self {
         let mut ret = Self::default();
         ret.property[17] = score;
         ret.property[18] = clear as u32;
         ret.property[19] = grade as u32;
 
         ret.property_nabla[18] = score;
+        ret.property_nabla[19] = ex_score;
         ret.property_nabla[20] = clear as u32;
         ret.property_nabla[21] = grade as u32;
 
@@ -64,6 +65,10 @@ impl Score {
         } else {
             &mut self.property[19]
         }
+    }
+
+    pub fn cloud_ex_score_mut(&mut self) -> &mut u32 {
+        &mut self.property_nabla[19]
     }
 
     pub fn to_property(self) -> Vec<u32> {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,6 +17,7 @@ pub struct GameProperties {
     valkyrie: bool,
     maxxive_support: bool,
     ultimate_support: bool,
+    nabla: bool,
 }
 
 pub enum NotSupportedReason<'a> {
@@ -43,6 +44,7 @@ impl GameProperties {
         let valkyrie = spec.as_ref() == "G" || spec.as_ref() == "H";
         let maxxive_support = ext >= 2025042200;
         let ultimate_support = ext >= 2025062400; // Actually it is 2025062401 but let's be more lenient
+        let nabla = ext > 2025120900;
 
         Some(GameProperties {
             model,
@@ -53,6 +55,7 @@ impl GameProperties {
             valkyrie,
             maxxive_support,
             ultimate_support,
+            nabla,
         })
     }
 
@@ -78,6 +81,10 @@ impl GameProperties {
 
     pub fn is_valkyrie(&self) -> bool {
         self.valkyrie
+    }
+
+    pub fn is_nabla(&self) -> bool {
+        self.nabla
     }
 
     pub fn has_maxxive_support(&self) -> bool {
@@ -110,6 +117,9 @@ impl Display for GameProperties {
         ))?;
         if self.valkyrie {
             f.write_str(" (Valkyrie)")?;
+        }
+        if self.nabla {
+            f.write_str(" (Nabla detected)")?;
         }
         if self.maxxive_support {
             f.write_str(" (Maxxive support)")?;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -44,7 +44,7 @@ impl GameProperties {
         let valkyrie = spec.as_ref() == "G" || spec.as_ref() == "H";
         let maxxive_support = ext >= 2025042200;
         let ultimate_support = ext >= 2025062400; // Actually it is 2025062401 but let's be more lenient
-        let nabla = ext > 2025120900;
+        let nabla = ext >= 2025122400;
 
         Some(GameProperties {
             model,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -87,6 +87,10 @@ impl GameProperties {
         self.nabla
     }
 
+    pub fn method_prefix(&self) -> &'static str {
+        if self.nabla { "sv7" } else { "sv6" }
+    }
+
     pub fn has_maxxive_support(&self) -> bool {
         self.maxxive_support
     }

--- a/src/types/tachi.rs
+++ b/src/types/tachi.rs
@@ -9,6 +9,14 @@ pub struct Import {
     pub scores: Vec<ImportScore>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ImportNabla {
+    pub meta: ImportMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classes: Option<ImportClasses>,
+    pub scores: Vec<ImportScoreNabla>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportMeta {
     pub game: String,
@@ -77,6 +85,21 @@ pub struct ImportScore {
     pub hit_meta: HitMeta,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportScoreNabla {
+    pub score: u32,
+    pub lamp: TachiLampNabla,
+    #[serde(rename = "matchType")]
+    pub match_type: String,
+    pub identifier: String,
+    pub difficulty: TachiDifficulty,
+    #[serde(rename = "timeAchieved")]
+    pub time_achieved: u128,
+    pub judgements: Judgements,
+    #[serde(rename = "hitMeta")]
+    pub hit_meta: HitMeta,
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, FromPrimitive, IntoPrimitive, Serialize, Deserialize)]
 #[repr(u32)]
 pub enum TachiLamp {
@@ -93,6 +116,24 @@ pub enum TachiLamp {
     PerfectUltimateChain = 5,
     #[serde(rename = "MAXXIVE CLEAR")]
     MaxxiveClear = 6,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, FromPrimitive, IntoPrimitive, Serialize, Deserialize)]
+#[repr(u32)]
+pub enum TachiLampNabla {
+    #[num_enum(default)]
+    #[serde(rename = "FAILED")]
+    Failed = 1,
+    #[serde(rename = "CLEAR")]
+    Clear = 2,
+    #[serde(rename = "EXCESSIVE CLEAR")]
+    ExcessiveClear = 3,
+    #[serde(rename = "ULTIMATE CHAIN")]
+    UltimateChain = 5,
+    #[serde(rename = "PERFECT ULTIMATE CHAIN")]
+    PerfectUltimateChain = 6,
+    #[serde(rename = "MAXXIVE CLEAR")]
+    MaxxiveClear = 4,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, FromPrimitive, IntoPrimitive, Serialize, Deserialize)]

--- a/src/types/tachi.rs
+++ b/src/types/tachi.rs
@@ -9,14 +9,6 @@ pub struct Import {
     pub scores: Vec<ImportScore>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ImportNabla {
-    pub meta: ImportMeta,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub classes: Option<ImportClasses>,
-    pub scores: Vec<ImportScoreNabla>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportMeta {
     pub game: String,
@@ -85,55 +77,66 @@ pub struct ImportScore {
     pub hit_meta: HitMeta,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImportScoreNabla {
-    pub score: u32,
-    pub lamp: TachiLampNabla,
-    #[serde(rename = "matchType")]
-    pub match_type: String,
-    pub identifier: String,
-    pub difficulty: TachiDifficulty,
-    #[serde(rename = "timeAchieved")]
-    pub time_achieved: u128,
-    pub judgements: Judgements,
-    #[serde(rename = "hitMeta")]
-    pub hit_meta: HitMeta,
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, FromPrimitive, IntoPrimitive, Serialize, Deserialize)]
-#[repr(u32)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TachiLamp {
-    #[num_enum(default)]
     #[serde(rename = "FAILED")]
-    Failed = 1,
+    Failed,
     #[serde(rename = "CLEAR")]
-    Clear = 2,
+    Clear,
     #[serde(rename = "EXCESSIVE CLEAR")]
-    ExcessiveClear = 3,
+    ExcessiveClear,
     #[serde(rename = "ULTIMATE CHAIN")]
-    UltimateChain = 4,
+    UltimateChain,
     #[serde(rename = "PERFECT ULTIMATE CHAIN")]
-    PerfectUltimateChain = 5,
+    PerfectUltimateChain,
     #[serde(rename = "MAXXIVE CLEAR")]
-    MaxxiveClear = 6,
+    MaxxiveClear,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, FromPrimitive, IntoPrimitive, Serialize, Deserialize)]
-#[repr(u32)]
-pub enum TachiLampNabla {
-    #[num_enum(default)]
-    #[serde(rename = "FAILED")]
-    Failed = 1,
-    #[serde(rename = "CLEAR")]
-    Clear = 2,
-    #[serde(rename = "EXCESSIVE CLEAR")]
-    ExcessiveClear = 3,
-    #[serde(rename = "ULTIMATE CHAIN")]
-    UltimateChain = 5,
-    #[serde(rename = "PERFECT ULTIMATE CHAIN")]
-    PerfectUltimateChain = 6,
-    #[serde(rename = "MAXXIVE CLEAR")]
-    MaxxiveClear = 4,
+impl TachiLamp {
+    pub fn from_eg(clear_type: u32) -> Self {
+        match clear_type {
+            2 => TachiLamp::Clear,
+            3 => TachiLamp::ExcessiveClear,
+            4 => TachiLamp::UltimateChain,
+            5 => TachiLamp::PerfectUltimateChain,
+            6 => TachiLamp::MaxxiveClear,
+            _ => TachiLamp::Failed,
+        }
+    }
+
+    pub fn from_nabla(clear_type: u32) -> Self {
+        match clear_type {
+            2 => TachiLamp::Clear,
+            3 => TachiLamp::ExcessiveClear,
+            4 => TachiLamp::MaxxiveClear,
+            5 => TachiLamp::UltimateChain,
+            6 => TachiLamp::PerfectUltimateChain,
+            _ => TachiLamp::Failed,
+        }
+    }
+
+    pub fn to_eg_index(&self) -> u32 {
+        match self {
+            TachiLamp::Failed => 1,
+            TachiLamp::Clear => 2,
+            TachiLamp::ExcessiveClear => 3,
+            TachiLamp::UltimateChain => 4,
+            TachiLamp::PerfectUltimateChain => 5,
+            TachiLamp::MaxxiveClear => 6,
+        }
+    }
+
+    pub fn to_nabla_index(&self) -> u32 {
+        match self {
+            TachiLamp::Failed => 1,
+            TachiLamp::Clear => 2,
+            TachiLamp::ExcessiveClear => 3,
+            TachiLamp::MaxxiveClear => 4,
+            TachiLamp::UltimateChain => 5,
+            TachiLamp::PerfectUltimateChain => 6,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, FromPrimitive, IntoPrimitive, Serialize, Deserialize)]


### PR DESCRIPTION
I have done the following adjustments, such that score upload, skill analyzer upload and konasute injection also work with Nabla:
- The hook checks to see if the game running is Nabla
- The hook intercepts methods starting with sv7 instead of sv6 when Nabla is detected
- The hook adjusts the lamp indices when Nabla is detected: UC, PUC and Maxxive are 5, 6 and 4 respectively instead of 4, 5 and 6
- Updated the music vector when injecting PBs. When Nabla is detected a 26 unit vector is used, and the konasute data is moved to its correct indices: 18, 20 and 21 instead of 17, 18 and 19
- Everything is unchanged if Nabla is not detected to retain backwards compatibility with EG

I have tested the code and made sure that the changes I made work. This was done through the following tests:
- Made sure that Tachi does not return an error when parsing the uploaded scores
- Made sure the uploaded scores match my played score (Songe name, score, lamp and grade)
- Made sure that the skill analyzer json is also parsed correctly by Tachi
- Checked that the Konasute injector correctly injects score, grade and lamp

This is my first time coding anything in Rust, so there will probably be a lot of unconventional code. I am happy to try and change the code to be more rust-like where needed.